### PR TITLE
refactor(ct-45): Remove .eslintcache from version control by adding it to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 /.idea
+.eslintcache


### PR DESCRIPTION
The purpose of this task it to remoe the .eslintcache file introduced in Create React App 4.0.1. The file is problematic because it changes constantly, affects time for compilation and in some cases  causes compile errors. The current work around for this as suggested here (https://github.com/facebook/create-react-app/issues/10161) is to add it to the .gitignore file or .dockerignore if applicable. 

https://trello.com/c/ifEdFkON/45-cleanup-remove-eslintcache-file-from-version-control-using-gitignore