### PR TITLE
hotfix(ct-#18): Removed the reference to counter reducer from the root reducer to fix crash bug

### DIFF
--- a/src/root-reducer.js
+++ b/src/root-reducer.js
@@ -1,6 +1,4 @@
 import { combineReducers } from '@reduxjs/toolkit'
-import counterReducer from "./features/counter/counterSlice";
 
 export default combineReducers({
-    counter: counterReducer
 })


### PR DESCRIPTION
This PR contains code to fix a bug that causes a crash in version 0.1.0 the first minor version of the app. The bug is caused by the counter reducer being used in the root reducer after it has been removed. 